### PR TITLE
[Liquid NFTs] An example for a liquid NFT similar to ERC-404

### DIFF
--- a/snippets/liquid-nfts/Move.toml
+++ b/snippets/liquid-nfts/Move.toml
@@ -1,0 +1,27 @@
+[package]
+name = "liquid-nfts"
+version = "1.0.0"
+authors = []
+# This should be immutable to ensure that shares are not burnt
+# upgrade_policy = "immutable"
+
+[addresses]
+fraction_addr = "_"
+
+[dev-addresses]
+fraction_addr = "0x1337"
+
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-core.git"
+rev = "mainnet"
+subdir = "aptos-move/framework/aptos-framework"
+
+[dependencies.AptosTokenObjects]
+git = "https://github.com/aptos-labs/aptos-core.git"
+rev = "mainnet"
+subdir = "aptos-move/framework/aptos-token-objects"
+
+[dependencies.AptosToken]
+git = "https://github.com/aptos-labs/aptos-core.git"
+rev = "mainnet"
+subdir = "aptos-move/framework/aptos-token"

--- a/snippets/liquid-nfts/sources/common.move
+++ b/snippets/liquid-nfts/sources/common.move
@@ -1,0 +1,74 @@
+module fraction_addr::common {
+
+    use std::option;
+    use std::string::String;
+    use aptos_framework::aptos_account;
+    use aptos_framework::coin;
+    use aptos_framework::coin::{destroy_mint_cap, destroy_freeze_cap, destroy_burn_cap};
+    use aptos_framework::fungible_asset;
+    use aptos_framework::object;
+    use aptos_framework::object::{ExtendRef, ConstructorRef};
+    use aptos_framework::primary_fungible_store;
+
+    friend fraction_addr::liquid_coin;
+    friend fraction_addr::liquid_coin_legacy;
+    friend fraction_addr::liquid_fungible_asset;
+
+    public(friend) inline fun create_sticky_object(
+        caller_address: address
+    ): (ConstructorRef, ExtendRef, signer, address) {
+        let constructor = object::create_sticky_object(caller_address);
+        let extend_ref = object::generate_extend_ref(&constructor);
+        let object_signer = object::generate_signer(&constructor);
+        let object_address = object::address_from_constructor_ref(&constructor);
+        (constructor, extend_ref, object_signer, object_address)
+    }
+
+    /// Mint the supply of the liquid token, destroying the mint capability afterwards
+    public(friend) inline fun create_coin<LiquidCoin>(
+        caller: &signer,
+        asset_name: String,
+        asset_symbol: String,
+        decimals: u8,
+        asset_supply: u64,
+        destination_address: address,
+    ) {
+        let (burn_cap, freeze_cap, mint_cap) = coin::initialize<LiquidCoin>(
+            caller,
+            asset_name,
+            asset_symbol,
+            decimals,
+            false
+        );
+        let coins = coin::mint(asset_supply, &mint_cap);
+        aptos_account::deposit_coins(destination_address, coins);
+        destroy_mint_cap(mint_cap);
+        destroy_freeze_cap(freeze_cap);
+        destroy_burn_cap(burn_cap);
+    }
+
+    public(friend) inline fun create_fungible_asset(
+        object_address: address,
+        constructor: &ConstructorRef,
+        asset_supply: u64,
+        asset_name: String,
+        asset_symbol: String,
+        decimals: u8,
+        collection_uri: String,
+        project_uri: String,
+    ) {
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            constructor,
+            option::some((asset_supply as u128)),
+            asset_name,
+            asset_symbol,
+            decimals,
+            collection_uri,
+            project_uri
+        );
+
+        // Mint the supply of the liquid token
+        let mint_ref = fungible_asset::generate_mint_ref(constructor);
+        primary_fungible_store::mint(&mint_ref, object_address, asset_supply);
+    }
+}

--- a/snippets/liquid-nfts/sources/common.move
+++ b/snippets/liquid-nfts/sources/common.move
@@ -1,19 +1,34 @@
+/// This is a common friend module
+///
+/// The friend module here is so that logic can be used between all versions of the liquid nft module
 module fraction_addr::common {
 
     use std::bcs;
+    use std::hash;
     use std::option;
     use std::string::String;
+    use std::vector;
     use aptos_std::from_bcs;
     use aptos_std::math64;
     use aptos_framework::aptos_account;
-    use aptos_framework::coin;
-    use aptos_framework::coin::{destroy_mint_cap, destroy_freeze_cap, destroy_burn_cap};
+    use aptos_framework::coin::{Self, destroy_mint_cap, destroy_freeze_cap, destroy_burn_cap};
     use aptos_framework::fungible_asset;
-    use aptos_framework::object;
-    use aptos_framework::object::{ExtendRef, ConstructorRef, Object};
+    use aptos_framework::object::{Self, ExtendRef, ConstructorRef, Object};
     use aptos_framework::primary_fungible_store;
+    use aptos_framework::timestamp;
     use aptos_framework::transaction_context;
+    #[test_only]
+    use std::signer;
+    #[test_only]
+    use std::string;
+    #[test_only]
+    use aptos_std::string_utils;
+    #[test_only]
+    use aptos_framework::account::create_account_for_test;
+    #[test_only]
+    use aptos_framework::genesis;
 
+    // These friends allow for other modules to use the friend functions in this module
     friend fraction_addr::liquid_coin;
     friend fraction_addr::liquid_coin_legacy;
     friend fraction_addr::liquid_fungible_asset;
@@ -38,6 +53,7 @@ module fraction_addr::common {
         asset_supply: u64,
         destination_address: address,
     ) {
+        // Create the coin
         let (burn_cap, freeze_cap, mint_cap) = coin::initialize<LiquidCoin>(
             caller,
             asset_name,
@@ -45,6 +61,8 @@ module fraction_addr::common {
             decimals,
             false
         );
+
+        // Mint the whole supply, and destroy the capabilities for mint, freeze, burn
         let coins = coin::mint(asset_supply, &mint_cap);
         aptos_account::deposit_coins(destination_address, coins);
         destroy_mint_cap(mint_cap);
@@ -52,6 +70,7 @@ module fraction_addr::common {
         destroy_burn_cap(burn_cap);
     }
 
+    /// Common logic for creating a fungible asset
     public(friend) inline fun create_fungible_asset(
         object_address: address,
         constructor: &ConstructorRef,
@@ -62,6 +81,9 @@ module fraction_addr::common {
         collection_uri: String,
         project_uri: String,
     ) {
+        // Create a fungible asset that can use a primary fungible store
+        // the primary fungible store makes it simple to use like a Coin, where there is a primary
+        // store that carries all the assets
         primary_fungible_store::create_primary_store_enabled_fungible_asset(
             constructor,
             option::some((asset_supply as u128)),
@@ -73,23 +95,172 @@ module fraction_addr::common {
         );
 
         // Mint the supply of the liquid token
+        // Note: The mint ref is dropped, so no more can be minted afterwards
         let mint_ref = fungible_asset::generate_mint_ref(constructor);
         primary_fungible_store::mint(&mint_ref, object_address, asset_supply);
     }
 
-
+    /// A convenience function, to get the entirety of 1 NFT in a coin's value
+    /// 10^decimals = 1.0...
     public(friend) inline fun one_nft_in_coins<LiquidCoin>(): u64 {
-        math64::pow(10, (coin::decimals<LiquidCoin>() as u64))
+        one_token_from_decimals((coin::decimals<LiquidCoin>()))
     }
 
+    /// A convenience function, to get the entirety of 1 NFT in a fungible asset's value
+    /// 10^decimals = 1.0...
     public(friend) inline fun one_nft_in_fungible_assets<T: key>(metadata: Object<T>): u64 {
-        math64::pow(10, (fungible_asset::decimals(metadata) as u64))
+        one_token_from_decimals(fungible_asset::decimals(metadata))
     }
 
+    public(friend) inline fun one_token_from_decimals(decimals: u8): u64 {
+        math64::pow(10, (decimals as u64))
+    }
+
+    /// Generate a pseudorandom number
+    ///
+    /// We use AUID to generate a number from the transaction hash and a globally unique
+    /// number, which allows us to spin this multiple times in a single transaction.
+    ///
+    /// We use timestamp to ensure that people can't predict it.
+    ///
     public(friend) inline fun pseudorandom_u64(size: u64): u64 {
         let auid = transaction_context::generate_auid_address();
         let bytes = bcs::to_bytes(&auid);
-        let val = from_bcs::to_u256(bytes) % (size as u256);
+        let time_bytes = bcs::to_bytes(&timestamp::now_microseconds());
+        vector::append(&mut bytes, time_bytes);
+
+        // Hash that together, and mod by the expected size
+        let hash = hash::sha3_256(bytes);
+        let val = from_bcs::to_u256(hash) % (size as u256);
         (val as u64)
+    }
+
+    #[test_only]
+    const COLLECTION_NAME: vector<u8> = b"MyCollection";
+    #[test_only]
+    const ASSET_NAME: vector<u8> = b"LiquidToken";
+    #[test_only]
+    const ASSET_SYMBOL: vector<u8> = b"L-NFT";
+    #[test_only]
+    const TOKEN_NAME: vector<u8> = b"Token";
+
+    #[test_only]
+    public(friend) fun setup_test(creator: &signer, collector: &signer): (address, address) {
+        genesis::setup();
+        let creator_address = signer::address_of(creator);
+        let collector_address = signer::address_of(collector);
+        create_account_for_test(creator_address);
+        create_account_for_test(collector_address);
+        (creator_address, collector_address)
+    }
+
+    #[test_only]
+    public(friend) fun create_token_collection(creator: &signer) {
+        create_token_collection_with_name(creator, string::utf8(COLLECTION_NAME))
+    }
+
+    #[test_only]
+    public(friend) fun create_token_collection_with_name(creator: &signer, name: String) {
+        aptos_token::token::create_collection_script(creator,
+            name,
+            string::utf8(b""),
+            string::utf8(b""),
+            5,
+            vector[false, false, false],
+        );
+    }
+
+    #[test_only]
+    public(friend) fun create_tokens(creator: &signer, collector: &signer) {
+        let collection_name = string::utf8(COLLECTION_NAME);
+        let creator_address = signer::address_of(creator);
+        for (i in 0..5) {
+            let name = token_name(i);
+            aptos_token::token::create_token_script(
+                creator,
+                collection_name,
+                name,
+                string::utf8(b""),
+                1,
+                1,
+                string::utf8(b""),
+                signer::address_of(creator),
+                1,
+                0,
+                vector[false, false, false, false, false],
+                vector[],
+                vector[],
+                vector[],
+            );
+
+            let token_id = token_id(creator_address, i);
+            aptos_token::token::direct_transfer(creator, collector, token_id, 1);
+        }
+    }
+
+    #[test_only]
+    public(friend) fun token_id(creator_address: address, i: u64): aptos_token::token::TokenId {
+        let token_data_id = aptos_token::token::create_token_data_id(
+            creator_address,
+            string::utf8(COLLECTION_NAME),
+            token_name(i)
+        );
+        aptos_token::token::create_token_id(
+            token_data_id,
+            aptos_token::token::get_tokendata_largest_property_version(creator_address, token_data_id)
+        )
+    }
+
+    #[test_only]
+    public(friend) fun token_name(i: u64): String {
+        string_utils::format2(&b"{}:{}", string::utf8(TOKEN_NAME), i)
+    }
+
+    #[test_only]
+    /// Create a collection just for testing
+    public(friend) fun create_token_objects_collection(
+        creator: &signer
+    ): Object<aptos_token_objects::collection::Collection> {
+        let constructor = aptos_token_objects::collection::create_fixed_collection(
+            creator,
+            string::utf8(b""),
+            5,
+            string::utf8(COLLECTION_NAME),
+            option::none(),
+            string::utf8(b""),
+        );
+        object::object_from_constructor_ref(&constructor)
+    }
+
+    #[test_only]
+    /// Create tokens and transfer them all to the collector
+    public(friend) fun create_token_objects(
+        creator: &signer,
+        collector: &signer
+    ): vector<Object<aptos_token_objects::token::Token>> {
+        let tokens = vector[];
+        let collection_name = string::utf8(COLLECTION_NAME);
+        let collector_address = signer::address_of(collector);
+
+        // Create 5 tokens with different names
+        for (i in 0..5) {
+            let name = token_name(i);
+            let constructor = aptos_token_objects::token::create(
+                creator,
+                collection_name,
+                string::utf8(b""),
+                name,
+                option::none(),
+                string::utf8(b""),
+            );
+
+            let token = object::object_from_constructor_ref(&constructor);
+            vector::push_back(&mut tokens, token);
+
+            // Transfer tokens to the collector
+            object::transfer(creator, token, collector_address);
+        };
+
+        tokens
     }
 }

--- a/snippets/liquid-nfts/sources/liquid_coin.move
+++ b/snippets/liquid-nfts/sources/liquid_coin.move
@@ -1,0 +1,157 @@
+/// Liquid coin allows for a coin liquidity on a set of TokenObjects
+///
+/// Note that tokens are mixed together in as if they were all the same value, and are
+/// randomly chosen when withdrawing.  This might have consequences where too many
+/// deposits & withdrawals happen in a short period of time, which can be counteracted with
+/// a timestamp cooldown either for an individual account, or for the whole pool.
+///
+/// How does this work?
+/// - User calls `liquify()` to get a set of liquid tokens associated with the NFT
+/// - They can now trade the coin directly
+/// - User can call `claim` which will withdraw a random NFT from the pool in exchange for tokens
+module fraction_addr::liquid_coin {
+
+    use std::bcs;
+    use std::option;
+    use std::signer;
+    use std::string::String;
+    use std::vector;
+    use aptos_std::from_bcs;
+    use aptos_std::smart_vector::{Self, SmartVector};
+    use aptos_framework::aptos_account;
+    use aptos_framework::coin;
+    use aptos_framework::object::{Self, Object, ExtendRef, object_address, is_owner};
+    use aptos_framework::transaction_context;
+    use aptos_token_objects::collection::{Self, Collection};
+    use aptos_token_objects::token;
+    use aptos_token_objects::token::{Token as TokenObject};
+    use fraction_addr::common;
+
+    /// Can't create fractionalize digital asset, not owner of collection
+    const E_NOT_OWNER_OF_COLLECTION: u64 = 1;
+    /// Can't liquify, not owner of token
+    const E_NOT_OWNER_OF_TOKEN: u64 = 2;
+    /// Can't redeem for tokens, not enough liquid tokens
+    const E_NOT_ENOUGH_LIQUID_TOKENS: u64 = 3;
+    /// Metadata object isn't for a fractionalized digital asset
+    const E_NOT_FRACTIONALIZED_DIGITAL_ASSET: u64 = 4;
+    /// Supply is not fixed, so we can't liquify this collection
+    const E_NOT_FIXED_SUPPLY: u64 = 5;
+    /// Token being liquified is not in the collection for the LiquidToken
+    const E_NOT_IN_COLLECTION: u64 = 6;
+
+    /// Metadata for a liquidity token for a collection
+    struct LiquidCoinMetadata<phantom LiquidCoin> has key {
+        /// The collection associated with the liquid token
+        collection: Object<Collection>,
+        /// Used for transferring objects
+        extend_ref: ExtendRef,
+        /// The list of all tokens locked up in the contract
+        token_pool: SmartVector<Object<TokenObject>>
+    }
+
+    /// Create a liquid token for a collection.
+    ///
+    /// The collection is assumed to be fixed, if the collection is not fixed, then this doesn't work quite correctly
+    entry fun create_liquid_token<LiquidCoin>(
+        caller: &signer,
+        collection: Object<Collection>,
+        asset_name: String,
+        asset_symbol: String,
+        decimals: u8,
+    ) {
+        // Assert ownership before fractionalizing, this is to ensure there are not duplicates of it
+        let caller_address = signer::address_of(caller);
+        assert!(object::is_owner(collection, caller_address), E_NOT_OWNER_OF_COLLECTION);
+
+        // Ensure collection is fixed, and determine the number of tokens to mint
+        let maybe_collection_supply = collection::count(collection);
+        assert!(option::is_some(&maybe_collection_supply), E_NOT_FIXED_SUPPLY);
+        let collection_supply = option::destroy_some(maybe_collection_supply);
+        let asset_supply = collection_supply * (decimals as u64);
+
+        // Build the object to hold the liquid token
+        // This must be a sticky object (a non-deleteable object) to be fungible
+        let (_, extend_ref, object_signer, object_address) = common::create_sticky_object(caller_address);
+
+        // Mint the supply of the liquid token, destroying the mint capability afterwards
+        common::create_coin<LiquidCoin>(caller, asset_name, asset_symbol, decimals, asset_supply, object_address);
+
+        move_to(&object_signer, LiquidCoinMetadata<LiquidCoin> {
+            collection, extend_ref, token_pool: smart_vector::new()
+        })
+    }
+
+    /// Allows for claiming a token from the collection
+    ///
+    /// The token claim is random from all the tokens stored in the contract
+    entry fun claim<LiquidCoin>(
+        caller: &signer,
+        metadata: Object<LiquidCoinMetadata<LiquidCoin>>,
+        count: u64
+    ) acquires LiquidCoinMetadata {
+        let caller_address = signer::address_of(caller);
+        let redeem_amount = one_token<LiquidCoin>() * count;
+
+        assert!(coin::balance<LiquidCoin>(caller_address) >= redeem_amount,
+            E_NOT_ENOUGH_LIQUID_TOKENS
+        );
+
+        let object_address = object_address(&metadata);
+        let liquid_token = borrow_global_mut<LiquidCoinMetadata<LiquidCoin>>(object_address);
+        let num_tokens = smart_vector::length(&liquid_token.token_pool);
+
+        // Transfer random token to caller
+        let random_nft_index = pseudorandom_u64(num_tokens);
+        let token = smart_vector::swap_remove(&mut liquid_token.token_pool, random_nft_index);
+        let object_signer = object::generate_signer_for_extending(&liquid_token.extend_ref);
+        object::transfer(&object_signer, token, caller_address);
+    }
+
+    /// Allows for liquifying a token from the collection
+    ///
+    /// Note: once a token is put into the
+    ///
+    entry fun liquify<LiquidCoin>(
+        caller: &signer,
+        metadata: Object<LiquidCoinMetadata<LiquidCoin>>,
+        tokens: vector<Object<TokenObject>>
+    ) acquires LiquidCoinMetadata {
+        let caller_address = signer::address_of(caller);
+        let liquidify_amount = one_token<LiquidCoin>() * vector::length(&tokens);
+        let object_address = object_address(&metadata);
+        let liquid_token = borrow_global_mut<LiquidCoinMetadata<LiquidCoin>>(object_address);
+
+        // Check ownership on all tokens and that they're in the collection
+        vector::for_each_ref(&tokens, |token| {
+            assert!(is_owner(*token, caller_address), E_NOT_OWNER_OF_TOKEN);
+            assert!(token::collection_object(*token) == liquid_token.collection, E_NOT_IN_COLLECTION);
+        });
+
+        // Ensure there's enough liquid tokens to send out
+        assert!(coin::balance<LiquidCoin>(object_address) >= liquidify_amount,
+            E_NOT_ENOUGH_LIQUID_TOKENS
+        );
+
+        // Take tokens add them to the pool
+        vector::for_each(tokens, |token| {
+            object::transfer(caller, token, object_address);
+            smart_vector::push_back(&mut liquid_token.token_pool, token);
+        });
+
+        // Return to caller liquidity coins
+        let object_signer = object::generate_signer_for_extending(&liquid_token.extend_ref);
+        aptos_account::transfer_coins<LiquidCoin>(&object_signer, caller_address, liquidify_amount);
+    }
+
+    inline fun one_token<LiquidCoin>(): u64 {
+        (coin::decimals<LiquidCoin>() as u64)
+    }
+
+    inline fun pseudorandom_u64(size: u64): u64 {
+        let auid = transaction_context::generate_auid_address();
+        let bytes = bcs::to_bytes(&auid);
+        let val = from_bcs::to_u256(bytes) % (size as u256);
+        (val as u64)
+    }
+}

--- a/snippets/liquid-nfts/sources/liquid_coin.move
+++ b/snippets/liquid-nfts/sources/liquid_coin.move
@@ -1,4 +1,4 @@
-/// Liquid coin allows for a coin liquidity on a set of TokenObjects
+/// Liquid coin allows for a coin liquidity on a set of TokenObjects (Token V2)
 ///
 /// Note that tokens are mixed together in as if they were all the same value, and are
 /// randomly chosen when withdrawing.  This might have consequences where too many
@@ -6,25 +6,24 @@
 /// a timestamp cooldown either for an individual account, or for the whole pool.
 ///
 /// How does this work?
-/// - User calls `liquify()` to get a set of liquid tokens associated with the NFT
+/// - Creator creates a token by calling `create_liquid_token()`
+/// - NFT owner calls `liquify()` to get a set of liquid coin in exchange for the NFT
 /// - They can now trade the coin directly
-/// - User can call `claim` which will withdraw a random NFT from the pool in exchange for tokens
+/// - User can call `claim()` which will withdraw a random NFT from the pool in exchange for tokens
 module fraction_addr::liquid_coin {
 
-    use std::bcs;
     use std::option;
     use std::signer;
     use std::string::String;
     use std::vector;
-    use aptos_std::from_bcs;
+    use aptos_std::math64;
     use aptos_std::smart_vector::{Self, SmartVector};
     use aptos_framework::aptos_account;
     use aptos_framework::coin;
     use aptos_framework::object::{Self, Object, ExtendRef, object_address, is_owner};
-    use aptos_framework::transaction_context;
     use aptos_token_objects::collection::{Self, Collection};
-    use aptos_token_objects::token;
-    use aptos_token_objects::token::{Token as TokenObject};
+    use aptos_token_objects::token::{Self, Token as TokenObject};
+    use fraction_addr::common::{one_nft_in_coins, pseudorandom_u64};
     use fraction_addr::common;
 
     /// Can't create fractionalize digital asset, not owner of collection
@@ -60,6 +59,16 @@ module fraction_addr::liquid_coin {
         asset_symbol: String,
         decimals: u8,
     ) {
+        create_liquid_token_internal<LiquidCoin>(caller, collection, asset_name, asset_symbol, decimals);
+    }
+
+    fun create_liquid_token_internal<LiquidCoin>(
+        caller: &signer,
+        collection: Object<Collection>,
+        asset_name: String,
+        asset_symbol: String,
+        decimals: u8,
+    ): Object<LiquidCoinMetadata<LiquidCoin>> {
         // Assert ownership before fractionalizing, this is to ensure there are not duplicates of it
         let caller_address = signer::address_of(caller);
         assert!(object::is_owner(collection, caller_address), E_NOT_OWNER_OF_COLLECTION);
@@ -68,7 +77,7 @@ module fraction_addr::liquid_coin {
         let maybe_collection_supply = collection::count(collection);
         assert!(option::is_some(&maybe_collection_supply), E_NOT_FIXED_SUPPLY);
         let collection_supply = option::destroy_some(maybe_collection_supply);
-        let asset_supply = collection_supply * (decimals as u64);
+        let asset_supply = collection_supply * math64::pow(10, (decimals as u64));
 
         // Build the object to hold the liquid token
         // This must be a sticky object (a non-deleteable object) to be fungible
@@ -79,7 +88,9 @@ module fraction_addr::liquid_coin {
 
         move_to(&object_signer, LiquidCoinMetadata<LiquidCoin> {
             collection, extend_ref, token_pool: smart_vector::new()
-        })
+        });
+
+        object::address_to_object(object_address)
     }
 
     /// Allows for claiming a token from the collection
@@ -91,21 +102,26 @@ module fraction_addr::liquid_coin {
         count: u64
     ) acquires LiquidCoinMetadata {
         let caller_address = signer::address_of(caller);
-        let redeem_amount = one_token<LiquidCoin>() * count;
+        let redeem_amount = one_nft_in_coins<LiquidCoin>() * count;
 
+        // Take coins
         assert!(coin::balance<LiquidCoin>(caller_address) >= redeem_amount,
             E_NOT_ENOUGH_LIQUID_TOKENS
         );
-
         let object_address = object_address(&metadata);
-        let liquid_token = borrow_global_mut<LiquidCoinMetadata<LiquidCoin>>(object_address);
-        let num_tokens = smart_vector::length(&liquid_token.token_pool);
+        coin::transfer<LiquidCoin>(caller, object_address, redeem_amount);
 
-        // Transfer random token to caller
-        let random_nft_index = pseudorandom_u64(num_tokens);
-        let token = smart_vector::swap_remove(&mut liquid_token.token_pool, random_nft_index);
-        let object_signer = object::generate_signer_for_extending(&liquid_token.extend_ref);
-        object::transfer(&object_signer, token, caller_address);
+        // Transfer tokens
+        for (i in 0..count) {
+            let liquid_token = borrow_global_mut<LiquidCoinMetadata<LiquidCoin>>(object_address);
+            let num_tokens = smart_vector::length(&liquid_token.token_pool);
+
+            // Transfer random token to caller
+            let random_nft_index = pseudorandom_u64(num_tokens);
+            let token = smart_vector::swap_remove(&mut liquid_token.token_pool, random_nft_index);
+            let object_signer = object::generate_signer_for_extending(&liquid_token.extend_ref);
+            object::transfer(&object_signer, token, caller_address);
+        }
     }
 
     /// Allows for liquifying a token from the collection
@@ -118,7 +134,7 @@ module fraction_addr::liquid_coin {
         tokens: vector<Object<TokenObject>>
     ) acquires LiquidCoinMetadata {
         let caller_address = signer::address_of(caller);
-        let liquidify_amount = one_token<LiquidCoin>() * vector::length(&tokens);
+        let liquidify_amount = one_nft_in_coins<LiquidCoin>() * vector::length(&tokens);
         let object_address = object_address(&metadata);
         let liquid_token = borrow_global_mut<LiquidCoinMetadata<LiquidCoin>>(object_address);
 
@@ -144,14 +160,109 @@ module fraction_addr::liquid_coin {
         aptos_account::transfer_coins<LiquidCoin>(&object_signer, caller_address, liquidify_amount);
     }
 
-    inline fun one_token<LiquidCoin>(): u64 {
-        (coin::decimals<LiquidCoin>() as u64)
+    #[test_only]
+    use std::string;
+    #[test_only]
+    use aptos_std::string_utils;
+    #[test_only]
+    use aptos_framework::account::create_account_for_test;
+    #[test_only]
+    use aptos_framework::genesis;
+    #[test_only]
+    use aptos_token_objects::token::Token;
+
+    #[test_only]
+    struct TestToken {}
+
+    #[test_only]
+    const COLLECTION_NAME: vector<u8> = b"MyCollection";
+    #[test_only]
+    const ASSET_NAME: vector<u8> = b"LiquidToken";
+    #[test_only]
+    const ASSET_SYMBOL: vector<u8> = b"L-NFT";
+    #[test_only]
+    const TOKEN_NAME: vector<u8> = b"Token";
+
+    #[test(creator = @fraction_addr, collector = @0xbeef)]
+    fun test_nft_e2e(creator: &signer, collector: &signer) acquires LiquidCoinMetadata {
+        genesis::setup();
+        let creator_address = signer::address_of(creator)  ;
+        let collector_address = signer::address_of(collector);
+        create_account_for_test(creator_address);
+        create_account_for_test(collector_address);
+
+        // Setup collection
+        let collection = create_collection(creator);
+        let tokens = create_tokens(creator, collector);
+
+        // Create liquid token
+        let metadata_object = create_liquid_token_internal<TestToken>(
+            creator,
+            collection,
+            string::utf8(ASSET_NAME),
+            string::utf8(ASSET_SYMBOL),
+            8,
+        );
+        let object_address = object::object_address(&metadata_object);
+
+        // Liquify some tokens
+        assert!(!coin::is_account_registered<TestToken>(collector_address), 0);
+
+        liquify(collector, metadata_object, vector[*vector::borrow(&tokens, 0), *vector::borrow(&tokens, 2)]);
+
+        assert!(coin::balance<TestToken>(collector_address) == 2 * one_nft_in_coins<TestToken>(), 2);
+
+        let metadata = borrow_global<LiquidCoinMetadata<TestToken>>(object_address);
+        assert!(2 == smart_vector::length(&metadata.token_pool), 3);
+
+        // Claim the NFTs back
+        claim(collector, metadata_object, 2);
+
+        assert!(coin::balance<TestToken>(collector_address) == 0, 4);
+        let metadata = borrow_global<LiquidCoinMetadata<TestToken>>(object_address);
+        assert!(0 == smart_vector::length(&metadata.token_pool), 5);
     }
 
-    inline fun pseudorandom_u64(size: u64): u64 {
-        let auid = transaction_context::generate_auid_address();
-        let bytes = bcs::to_bytes(&auid);
-        let val = from_bcs::to_u256(bytes) % (size as u256);
-        (val as u64)
+    #[test_only]
+    fun create_collection(creator: &signer): Object<Collection> {
+        let constructor = collection::create_fixed_collection(
+            creator,
+            string::utf8(b""),
+            5,
+            string::utf8(COLLECTION_NAME),
+            option::none(),
+            string::utf8(b""),
+        );
+        object::object_from_constructor_ref(&constructor)
+    }
+
+    #[test_only]
+    fun create_tokens(creator: &signer, collector: &signer): vector<Object<Token>> {
+        let tokens = vector[];
+        let collection_name = string::utf8(COLLECTION_NAME);
+        let collector_address = signer::address_of(collector);
+        for (i in 0..5) {
+            let name = token_name(i);
+            let constructor = token::create(
+                creator,
+                collection_name,
+                string::utf8(b""),
+                name,
+                option::none(),
+                string::utf8(b""),
+            );
+
+            let token = object::object_from_constructor_ref(&constructor);
+            vector::push_back(&mut tokens, token);
+
+            object::transfer(creator, token, collector_address);
+        };
+
+        tokens
+    }
+
+    #[test_only]
+    fun token_name(i: u64): String {
+        string_utils::format2(&b"{}:{}", string::utf8(TOKEN_NAME), i)
     }
 }

--- a/snippets/liquid-nfts/sources/liquid_coin_legacy.move
+++ b/snippets/liquid-nfts/sources/liquid_coin_legacy.move
@@ -1,0 +1,184 @@
+/// Liquid coin legacy allows for a coin liquidity on a set of Legacy Tokens
+///
+/// Note that tokens are mixed together in as if they were all the same value, and are
+/// randomly chosen when withdrawing.  This might have consequences where too many
+/// deposits & withdrawals happen in a short period of time, which can be counteracted with
+/// a timestamp cooldown either for an individual account, or for the whole pool.
+///
+/// How does this work?
+/// - User calls `liquify()` to get a set of liquid tokens associated with the NFT
+/// - They can now trade the coin directly
+/// - User can call `claim` which will withdraw a random NFT from the pool in exchange for tokens
+///
+/// Note that withdrawals and deposits of Legacy Tokens can be expensive from a gas perspective
+module fraction_addr::liquid_coin_legacy {
+
+    use std::bcs;
+    use std::option;
+    use std::signer;
+    use std::string::String;
+    use std::vector;
+    use aptos_std::from_bcs;
+    use aptos_std::smart_vector::{Self, SmartVector};
+    use aptos_framework::aptos_account;
+    use aptos_framework::coin;
+    use aptos_framework::object::{Self, Object, ExtendRef, object_address};
+    use aptos_framework::transaction_context;
+    use aptos_token::token;
+    use aptos_token::token::{check_collection_exists, get_collection_supply};
+    use fraction_addr::common;
+
+    /// Can't create fractionalize digital asset, not owner of collection
+    const E_NOT_OWNER_OF_COLLECTION: u64 = 1;
+    /// Can't liquify, not owner of token
+    const E_NOT_OWNER_OF_TOKEN: u64 = 2;
+    /// Can't redeem for tokens, not enough liquid tokens
+    const E_NOT_ENOUGH_LIQUID_TOKENS: u64 = 3;
+    /// Metadata object isn't for a fractionalized digital asset
+    const E_NOT_FRACTIONALIZED_DIGITAL_ASSET: u64 = 4;
+    /// Supply is not fixed, so we can't liquify this collection
+    const E_NOT_FIXED_SUPPLY: u64 = 5;
+    /// Token being liquified is not in the collection for the LiquidToken
+    const E_NOT_IN_COLLECTION: u64 = 6;
+    /// Can't liquify, token not an NFT
+    const E_NOT_A_NON_FUNGIBLE_TOKEN: u64 = 7;
+
+    /// Metadata for a liquidity token for a collection
+    struct LiquidCoinMetadata<phantom LiquidCoin> has key {
+        creator: address,
+        /// The collection associated with the liquid token
+        collection_name: String,
+        /// Used for transferring objects
+        extend_ref: ExtendRef,
+        /// The list of all tokens locked up in the contract
+        token_pool: SmartVector<String>
+    }
+
+    /// Create a liquid token for a collection.
+    ///
+    /// The collection is assumed to be fixed, if the collection is not fixed, then this doesn't work quite correctly
+    entry fun create_liquid_token<LiquidCoin>(
+        caller: &signer,
+        collection_name: String,
+        asset_name: String,
+        asset_symbol: String,
+        decimals: u8,
+    ) {
+        // Assert ownership before fractionalizing, this is to ensure there are not duplicates of it
+        let caller_address = signer::address_of(caller);
+        assert!(check_collection_exists(caller_address, collection_name), E_NOT_OWNER_OF_COLLECTION);
+
+        // Ensure collection is fixed, and determine the number of tokens to mint
+        let maybe_collection_supply = get_collection_supply(caller_address, collection_name);
+        assert!(option::is_some(&maybe_collection_supply), E_NOT_FIXED_SUPPLY);
+        let collection_supply = option::destroy_some(maybe_collection_supply);
+        let asset_supply = collection_supply * (decimals as u64);
+
+        // Build the object to hold the liquid token
+        // This must be a sticky object (a non-deleteable object) to be fungible
+        let (_, extend_ref, object_signer, object_address) = common::create_sticky_object(caller_address);
+
+        // Mint the supply of the liquid token, destroying the mint capability afterwards
+        common::create_coin<LiquidCoin>(caller, asset_name, asset_symbol, decimals, asset_supply, object_address);
+
+        move_to(&object_signer, LiquidCoinMetadata<LiquidCoin> {
+            creator: caller_address, collection_name, extend_ref, token_pool: smart_vector::new()
+        })
+    }
+
+    /// Allows for claiming a token from the collection
+    ///
+    /// The token claim is random from all the tokens stored in the contract
+    entry fun claim<LiquidCoin>(
+        caller: &signer,
+        metadata: Object<LiquidCoinMetadata<LiquidCoin>>,
+        count: u64
+    ) acquires LiquidCoinMetadata {
+        let caller_address = signer::address_of(caller);
+        let redeem_amount = one_token<LiquidCoin>() * count;
+
+        assert!(coin::balance<LiquidCoin>(caller_address) >= redeem_amount,
+            E_NOT_ENOUGH_LIQUID_TOKENS
+        );
+
+        let object_address = object_address(&metadata);
+        let liquid_token = borrow_global_mut<LiquidCoinMetadata<LiquidCoin>>(object_address);
+        let num_tokens = smart_vector::length(&liquid_token.token_pool);
+
+        // Transfer random token to caller
+        let random_nft_index = pseudorandom_u64(num_tokens);
+        let token_name = smart_vector::swap_remove(&mut liquid_token.token_pool, random_nft_index);
+        let object_signer = object::generate_signer_for_extending(&liquid_token.extend_ref);
+
+        // Build up the token id
+        let creator_address = liquid_token.creator;
+        let collection_name = liquid_token.collection_name;
+        let data_id = token::create_token_data_id(creator_address, collection_name, token_name);
+        let latest_property_version = token::get_tokendata_largest_property_version(creator_address, data_id);
+        let token_id = token::create_token_id(data_id, latest_property_version);
+
+        // Direct transfer to caller, assuming only 1 for an NFT
+        token::direct_transfer(&object_signer, caller, token_id, 1);
+        smart_vector::push_back(&mut liquid_token.token_pool, token_name);
+    }
+
+    /// Allows for liquifying a token from the collection
+    ///
+    /// Note: once a token is put into the
+    ///
+    entry fun liquify<LiquidCoin>(
+        caller: &signer,
+        metadata: Object<LiquidCoinMetadata<LiquidCoin>>,
+        token_names: vector<String>
+    ) acquires LiquidCoinMetadata {
+        let caller_address = signer::address_of(caller);
+        let liquidify_amount = one_token<LiquidCoin>() * vector::length(&token_names);
+        let object_address = object_address(&metadata);
+        let liquid_token = borrow_global_mut<LiquidCoinMetadata<LiquidCoin>>(object_address);
+        let object_signer = object::generate_signer_for_extending(&liquid_token.extend_ref);
+
+        // Ensure there's enough liquid tokens to send out
+        assert!(coin::balance<LiquidCoin>(object_address) >= liquidify_amount,
+            E_NOT_ENOUGH_LIQUID_TOKENS
+        );
+
+        // Check ownership on all tokens and that they're in the collection
+        vector::for_each(token_names, |token_name| {
+            // Check that the token exists
+            let creator_address = liquid_token.creator;
+            let collection_name = liquid_token.collection_name;
+            let data_id = token::create_token_data_id(creator_address, collection_name, token_name);
+
+            // Ensure this is an NFT
+            assert!(token::check_tokendata_exists(creator_address, collection_name, token_name), E_NOT_IN_COLLECTION);
+            let token_supply = token::get_token_supply(creator_address, data_id);
+            assert!(
+                option::is_some(&token_supply) && option::destroy_some(token_supply) == 1,
+                E_NOT_A_NON_FUNGIBLE_TOKEN
+            );
+
+            let latest_property_version = token::get_tokendata_largest_property_version(creator_address, data_id);
+            let token_id = token::create_token_id(data_id, latest_property_version);
+
+            // Direct transfer to object, assuming only 1 for an NFT
+            assert!(token::balance_of(caller_address, token_id) == 1, E_NOT_OWNER_OF_TOKEN);
+            token::direct_transfer(caller, &object_signer, token_id, 1);
+            smart_vector::push_back(&mut liquid_token.token_pool, token_name);
+        });
+
+        // Return to caller liquidity coins
+        let object_signer = object::generate_signer_for_extending(&liquid_token.extend_ref);
+        aptos_account::transfer_coins<LiquidCoin>(&object_signer, caller_address, liquidify_amount);
+    }
+
+    inline fun one_token<LiquidCoin>(): u64 {
+        (coin::decimals<LiquidCoin>() as u64)
+    }
+
+    inline fun pseudorandom_u64(size: u64): u64 {
+        let auid = transaction_context::generate_auid_address();
+        let bytes = bcs::to_bytes(&auid);
+        let val = from_bcs::to_u256(bytes) % (size as u256);
+        (val as u64)
+    }
+}

--- a/snippets/liquid-nfts/sources/liquid_fungible_asset.move
+++ b/snippets/liquid-nfts/sources/liquid_fungible_asset.move
@@ -1,0 +1,165 @@
+/// Liquid fungible asset allows for a fungible asset liquidity on a set of TokenObjects
+///
+/// Note that tokens are mixed together in as if they were all the same value, and are
+/// randomly chosen when withdrawing.  This might have consequences where too many
+/// deposits & withdrawals happen in a short period of time, which can be counteracted with
+/// a timestamp cooldown either for an individual account, or for the whole pool.
+///
+/// How does this work?
+/// - User calls `liquify()` to get a set of liquid tokens associated with the NFT
+/// - They can now trade the fungible asset directly
+/// - User can call `claim` which will withdraw a random NFT from the pool in exchange for tokens
+module fraction_addr::liquid_fungible_asset {
+
+    use std::bcs;
+    use std::option;
+    use std::signer;
+    use std::string::String;
+    use std::vector;
+    use aptos_std::from_bcs;
+    use aptos_std::smart_vector::{Self, SmartVector};
+    use aptos_framework::fungible_asset::{Self};
+    use aptos_framework::object::{Self, Object, ExtendRef, object_address, is_owner};
+    use aptos_framework::primary_fungible_store;
+    use aptos_framework::transaction_context;
+    use aptos_token_objects::collection::{Self, Collection};
+    use aptos_token_objects::token;
+    use aptos_token_objects::token::{Token as TokenObject};
+    use fraction_addr::common;
+
+    /// Can't create fractionalize digital asset, not owner of collection
+    const E_NOT_OWNER_OF_COLLECTION: u64 = 1;
+    /// Can't liquify, not owner of token
+    const E_NOT_OWNER_OF_TOKEN: u64 = 2;
+    /// Can't redeem for tokens, not enough liquid tokens
+    const E_NOT_ENOUGH_LIQUID_TOKENS: u64 = 3;
+    /// Metadata object isn't for a fractionalized digital asset
+    const E_NOT_FRACTIONALIZED_DIGITAL_ASSET: u64 = 4;
+    /// Supply is not fixed, so we can't liquify this collection
+    const E_NOT_FIXED_SUPPLY: u64 = 5;
+    /// Token being liquified is not in the collection for the LiquidToken
+    const E_NOT_IN_COLLECTION: u64 = 6;
+
+    /// Metadata for a liquidity token for a collection
+    struct LiquidTokenMetadata has key {
+        /// The collection associated with the liquid token
+        collection: Object<Collection>,
+        /// Used for transferring objects
+        extend_ref: ExtendRef,
+        /// The list of all tokens locked up in the contract
+        token_pool: SmartVector<Object<TokenObject>>
+    }
+
+    /// Create a liquid token for a collection.
+    ///
+    /// The collection is assumed to be fixed, if the collection is not fixed, then this doesn't work quite correctly
+    entry fun create_liquid_token(
+        caller: &signer,
+        collection: Object<Collection>,
+        asset_name: String,
+        asset_symbol: String,
+        decimals: u8,
+        project_uri: String,
+    ) {
+        // Assert ownership before fractionalizing, this is to ensure there are not duplicates of it
+        let caller_address = signer::address_of(caller);
+        assert!(object::is_owner(collection, caller_address), E_NOT_OWNER_OF_COLLECTION);
+
+        // Ensure collection is fixed, and determine the number of tokens to mint
+        let maybe_collection_supply = collection::count(collection);
+        assert!(option::is_some(&maybe_collection_supply), E_NOT_FIXED_SUPPLY);
+        let collection_supply = option::destroy_some(maybe_collection_supply);
+        let asset_supply = collection_supply * (decimals as u64);
+
+        // Build the object to hold the liquid token
+        // This must be a sticky object (a non-deleteable object) to be fungible
+        let (constructor, extend_ref, object_signer, object_address) = common::create_sticky_object(caller_address);
+        let collection_uri = collection::uri(collection);
+        common::create_fungible_asset(
+            object_address,
+            &constructor,
+            asset_supply,
+            asset_name,
+            asset_symbol,
+            decimals,
+            collection_uri,
+            project_uri
+        );
+
+        move_to(&object_signer, LiquidTokenMetadata {
+            collection, extend_ref, token_pool: smart_vector::new()
+        })
+    }
+
+    /// Allows for claiming a token from the collection
+    ///
+    /// The token claim is random from all the tokens stored in the contract
+    entry fun claim(caller: &signer, metadata: Object<LiquidTokenMetadata>, count: u64) acquires LiquidTokenMetadata {
+        let caller_address = signer::address_of(caller);
+        let redeem_amount = one_token(metadata) * count;
+
+        assert!(primary_fungible_store::balance(caller_address, metadata) >= redeem_amount,
+            E_NOT_ENOUGH_LIQUID_TOKENS
+        );
+
+        let object_address = object_address(&metadata);
+        let liquid_token = borrow_global_mut<LiquidTokenMetadata>(object_address);
+        let num_tokens = smart_vector::length(&liquid_token.token_pool);
+
+        // Take liquid tokens back to the object
+        primary_fungible_store::transfer(caller, metadata, object_address, redeem_amount);
+
+        // Transfer random token to caller
+        let random_nft_index = pseudorandom_u64(num_tokens);
+        let token = smart_vector::swap_remove(&mut liquid_token.token_pool, random_nft_index);
+        let object_signer = object::generate_signer_for_extending(&liquid_token.extend_ref);
+        object::transfer(&object_signer, token, caller_address);
+    }
+
+    /// Allows for liquifying a token from the collection
+    ///
+    /// Note: once a token is put into the
+    ///
+    entry fun liquify(
+        caller: &signer,
+        metadata: Object<LiquidTokenMetadata>,
+        tokens: vector<Object<TokenObject>>
+    ) acquires LiquidTokenMetadata {
+        let caller_address = signer::address_of(caller);
+        let liquidify_amount = one_token(metadata) * vector::length(&tokens);
+        let object_address = object_address(&metadata);
+        let liquid_token = borrow_global_mut<LiquidTokenMetadata>(object_address);
+
+        // Check ownership on all tokens and that they're in the collection
+        vector::for_each_ref(&tokens, |token| {
+            assert!(is_owner(*token, caller_address), E_NOT_OWNER_OF_TOKEN);
+            assert!(token::collection_object(*token) == liquid_token.collection, E_NOT_IN_COLLECTION);
+        });
+
+        // Ensure there's enough liquid tokens to send out
+        assert!(primary_fungible_store::balance(object_address, metadata) >= liquidify_amount,
+            E_NOT_ENOUGH_LIQUID_TOKENS
+        );
+
+        // Take tokens add them to the pool
+        vector::for_each(tokens, |token| {
+            object::transfer(caller, token, object_address);
+            smart_vector::push_back(&mut liquid_token.token_pool, token);
+        });
+
+        // Return to caller liquidity tokens
+        let object_signer = object::generate_signer_for_extending(&liquid_token.extend_ref);
+        primary_fungible_store::transfer(&object_signer, metadata, caller_address, liquidify_amount);
+    }
+
+    inline fun one_token(metadata: Object<LiquidTokenMetadata>): u64 {
+        (fungible_asset::decimals(metadata) as u64)
+    }
+
+    inline fun pseudorandom_u64(size: u64): u64 {
+        let auid = transaction_context::generate_auid_address();
+        let bytes = bcs::to_bytes(&auid);
+        let val = from_bcs::to_u256(bytes) % (size as u256);
+        (val as u64)
+    }
+}


### PR DESCRIPTION
This gives an example similar to ERC-404, with the following properties:
1. All NFTs in a collection are treated as the same liquid tokens
2. All NFTs can be redeemed when a full liquid token 1.00... is given
3. NFTs can be made liquid by depositing an NFT and getting out a full liquid token 1.00...
4. When pulling an NFT out of the pool, it will randomly choose which NFT to withdraw