### PR TITLE
[fix] Add resource groups to properly handle storage

### DIFF
--- a/snippets/liquid-nfts/sources/liquid_coin.move
+++ b/snippets/liquid-nfts/sources/liquid_coin.move
@@ -39,6 +39,7 @@ module fraction_addr::liquid_coin {
     /// Token being liquified is not in the collection for the LiquidToken
     const E_NOT_IN_COLLECTION: u64 = 6;
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// Metadata for a liquidity token for a collection
     struct LiquidCoinMetadata<phantom LiquidCoin> has key {
         /// The collection associated with the liquid token

--- a/snippets/liquid-nfts/sources/liquid_coin_legacy.move
+++ b/snippets/liquid-nfts/sources/liquid_coin_legacy.move
@@ -42,6 +42,7 @@ module fraction_addr::liquid_coin_legacy {
     /// Can't liquify, token not an NFT
     const E_NOT_A_NON_FUNGIBLE_TOKEN: u64 = 7;
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// Metadata for a liquidity token for a collection
     struct LiquidCoinMetadata<phantom LiquidCoin> has key {
         creator: address,

--- a/snippets/liquid-nfts/sources/liquid_fungible_asset.move
+++ b/snippets/liquid-nfts/sources/liquid_fungible_asset.move
@@ -37,6 +37,7 @@ module fraction_addr::liquid_fungible_asset {
     /// Token being liquified is not in the collection for the LiquidToken
     const E_NOT_IN_COLLECTION: u64 = 6;
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// Metadata for a liquidity token for a collection
     struct LiquidTokenMetadata has key {
         /// The collection associated with the liquid token

--- a/snippets/modifying-nfts/sources/modify_nfts.move
+++ b/snippets/modifying-nfts/sources/modify_nfts.move
@@ -30,17 +30,20 @@ module deploy_addr::modify_nfts {
     /// A URI we're using here for the demo, this could be anything, mp4, ipfs, svg, png, gif, jpg, etc.
     const URI: vector<u8> = b"https://aptosfoundation.org/_next/static/media/globe.f620f2d6.svg";
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// A struct holding items to control properties of a collection
     struct CollectionController has key {
         extend_ref: object::ExtendRef,
         mutator_ref: collection::MutatorRef,
     }
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// A struct for representing extension of a collection
     struct CollectionPoints has key {
         total_points: u64
     }
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// A struct holding items to control properties of a token
     struct TokenController has key {
         extend_ref: object::ExtendRef,
@@ -48,6 +51,7 @@ module deploy_addr::modify_nfts {
         burn_ref: token::BurnRef,
     }
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// A struct for representing extension of a token
     struct TokenPoints has key {
         points: u64


### PR DESCRIPTION
Resource groups allow for objects to be stored at a single slot, this is important for performance storage reasons.