### PR TITLE
Assert that token cannot be sent back to creator when not recombined

### DIFF
--- a/snippets/fractional-token/Move.toml
+++ b/snippets/fractional-token/Move.toml
@@ -7,9 +7,11 @@ authors = []
 
 [addresses]
 fraction_addr = "_"
+minter = "_"
 
 [dev-addresses]
 fraction_addr = "0x1337"
+minter = "0x2337"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
@@ -20,3 +22,8 @@ subdir = "aptos-move/framework/aptos-framework"
 git = "https://github.com/aptos-labs/aptos-core.git"
 rev = "mainnet"
 subdir = "aptos-move/framework/aptos-token-objects"
+
+[dependencies.TokenMinter]
+git = 'https://github.com/aptos-labs/token-minter.git'
+rev = 'main'
+subdir = 'token-minter/'

--- a/snippets/fractional-token/tests/common_tests.move
+++ b/snippets/fractional-token/tests/common_tests.move
@@ -1,0 +1,92 @@
+#[test_only]
+module fraction_addr::common_tests {
+
+    use std::option;
+    use std::signer;
+    use std::string;
+    use std::string::String;
+    use std::vector;
+    use aptos_std::string_utils;
+    use aptos_framework::account::create_account_for_test;
+    use aptos_framework::genesis;
+    use aptos_framework::object;
+    use aptos_framework::object::Object;
+
+    use aptos_token_objects::collection;
+    use aptos_token_objects::collection::Collection;
+    use aptos_token_objects::token;
+    use aptos_token_objects::token::Token;
+
+    use minter::collection_components;
+    use minter::token_components;
+
+    #[test_only]
+    const COLLECTION_NAME: vector<u8> = b"MyCollection";
+    #[test_only]
+    const ASSET_NAME: vector<u8> = b"LiquidToken";
+    #[test_only]
+    const ASSET_SYMBOL: vector<u8> = b"L-NFT";
+    #[test_only]
+    const TOKEN_NAME: vector<u8> = b"Token";
+    #[test_only]
+    const TOKEN_DESCRIPTION: vector<u8> = b"Token description";
+
+    #[test_only]
+    public fun setup_test(creator: &signer, collector: &signer): (address, address) {
+        genesis::setup();
+        let creator_address = signer::address_of(creator);
+        let collector_address = signer::address_of(collector);
+        create_account_for_test(creator_address);
+        create_account_for_test(collector_address);
+        (creator_address, collector_address)
+    }
+
+    #[test_only]
+    public fun create_collection(creator: &signer): Object<Collection> {
+        create_token_collection_with_name(creator, string::utf8(COLLECTION_NAME))
+    }
+
+    #[test_only]
+    public fun create_token_collection_with_name(creator: &signer, name: String): Object<Collection> {
+        let constructor_ref = &collection::create_unlimited_collection(
+            creator,
+            string::utf8(b"Collection description"),
+            name,
+            option::none(),
+            string::utf8(b"https://collectionUri"),
+        );
+        collection_components::create_refs_and_properties(constructor_ref);
+
+        object::object_from_constructor_ref(constructor_ref)
+    }
+
+    #[test_only]
+    public fun create_tokens(creator: &signer): vector<Object<Token>> {
+        let collection_name = string::utf8(COLLECTION_NAME);
+        let tokens = vector[];
+        for (i in 0..5) {
+            let constructor_ref = &token::create(
+                creator,
+                collection_name,
+                token_description(i),
+                token_name(i),
+                option::none(),
+                string::utf8(b"http://tokenUri.com"),
+            );
+            let refs = token_components::create_refs(constructor_ref);
+            vector::push_back(&mut tokens, object::convert(refs));
+        };
+
+        tokens
+    }
+
+    #[test_only]
+    public fun token_name(i: u64): String {
+        string_utils::format2(&b"{}:{}", string::utf8(TOKEN_NAME), i)
+    }
+
+    #[test_only]
+    public fun token_description(i: u64): String {
+        string_utils::format2(&b"{}:{}", string::utf8(TOKEN_DESCRIPTION), i)
+    }
+}

--- a/snippets/fractional-token/tests/fractional_token_tests.move
+++ b/snippets/fractional-token/tests/fractional_token_tests.move
@@ -1,0 +1,53 @@
+#[test_only]
+module fraction_addr::fractional_token_tests {
+    use std::signer::address_of;
+    use std::vector;
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object;
+
+    use fraction_addr::common_tests::{create_collection, create_tokens, setup_test};
+    use fraction_addr::fractional_token::{fractionalize_asset_test_only, metadata_object_address,
+        recombine_asset_test_only
+    };
+
+    #[test(creator = @fraction_addr, collector = @0xbeef)]
+    fun test_fractionalize_nft_e2e(creator: &signer, collector: &signer) {
+        let creator_addr = address_of(creator);
+        setup_test(creator, collector);
+
+        // Setup collection
+        create_collection(creator);
+        let tokens = create_tokens(creator);
+        let token = *vector::borrow(&tokens, 0);
+
+        // Fractionalize token into 10 fungible tokens
+        fractionalize_asset_test_only(creator, token, 10);
+
+        let object_metadata_address = metadata_object_address(creator);
+        assert!(object::owner(token) == object_metadata_address, 0);
+
+        let metadata = object::address_to_object<Metadata>(object_metadata_address);
+        // Recombine token
+        recombine_asset_test_only(creator, metadata);
+
+        assert!(object::owner(token) == creator_addr, 0);
+    }
+
+    #[test(creator = @fraction_addr, collector = @0xbeef)]
+    #[expected_failure(abort_code = 0x50003, location = aptos_framework::object)]
+    fun exception_when_user_tries_to_transfer_token_after_fractionalizing(creator: &signer, collector: &signer) {
+        let creator_addr = address_of(creator);
+        setup_test(creator, collector);
+
+        // Setup collection
+        create_collection(creator);
+        let tokens = create_tokens(creator);
+        let token = *vector::borrow(&tokens, 0);
+
+        // Fractionalize token into 10 fungible tokens
+        fractionalize_asset_test_only(creator, token, 10);
+
+        // Try to transfer the token back to the user, this will fail as they have not recombined the token
+        object::transfer(creator, token, creator_addr);
+    }
+}


### PR DESCRIPTION
## Description
Amended the logic where the NFT cannot be sent back to the creator unless the asset as been recombined