### PR TITLE
deduplicate aptos-framework in fractional-token package

### DIFF
--- a/snippets/fractional-token/Move.toml
+++ b/snippets/fractional-token/Move.toml
@@ -14,14 +14,14 @@ fraction_addr = "0x1337"
 minter = "0x2337"
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-framework.git"
+git = "https://github.com/aptos-labs/aptos-core.git"
 rev = "mainnet"
-subdir = "aptos-framework"
+subdir = "aptos-move/framework/aptos-framework"
 
 [dependencies.AptosTokenObjects]
-git = "https://github.com/aptos-labs/aptos-framework.git"
+git = "https://github.com/aptos-labs/aptos-core.git"
 rev = "mainnet"
-subdir = "aptos-token-objects"
+subdir = "aptos-move/framework/aptos-token-objects"
 
 [dev-dependencies.TokenMinter]
 git = 'https://github.com/aptos-labs/token-minter.git'


### PR DESCRIPTION
@gregnazario 
Required for the VSCode plugin CI to pass, otherwise there's two aptos-framework packages and in one place language server cannot deduplicate. 

It's really a bug in the language server, but the fix is very involved, and I'm planning to instead fix it when `aptos metadata` from the new Package System is available. 