### PR TITLE
CI examples tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,46 +10,6 @@ jobs:
   compile:
     name: Compile Examples
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: composable-nfts
-            path: snippets/composable-nfts
-          - name: controlled-mint
-            path: snippets/controlled-mint
-          - name: data-structures-heap
-            path: snippets/data-structures/heap
-          - name: autonomous-objects
-            path: snippets/design-patterns/autonomous-objects
-          - name: error-codes
-            path: snippets/error-codes
-          - name: fa-lockup-example
-            path: snippets/fa-lockup-example
-          - name: fractional-token
-            path: snippets/fractional-token
-            # Uses --named-addresses instead of --dev due to broken TokenMinter dev-dependency
-            compile_flags: "--named-addresses fraction_addr=0x1337,minter=0x2337"
-          - name: liquid-nfts
-            path: snippets/liquid-nfts
-          - name: lootbox
-            path: snippets/lootbox
-          - name: modifying-nfts
-            path: snippets/modifying-nfts
-          - name: objects
-            path: snippets/objects
-          - name: parallel-nfts
-            path: snippets/parallel-nfts
-          - name: private-vs-public-dice-roll
-            path: snippets/private-vs-public/dice_roll
-          - name: private-vs-public-cheater
-            path: snippets/private-vs-public/cheater
-          - name: prover
-            path: snippets/prover
-          - name: storage
-            path: snippets/storage
-          - name: struct-capabilities
-            path: snippets/struct-capabilities
 
     steps:
       - name: Checkout repository
@@ -60,25 +20,55 @@ jobs:
           curl -fsSL "https://aptos.dev/scripts/install_cli.py" | python3
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Compile ${{ matrix.name }}
-        working-directory: ${{ matrix.path }}
-        run: aptos move compile ${{ matrix.compile_flags || '--dev' }}
+      - name: Compile all examples
+        run: |
+          packages=(
+            "snippets/composable-nfts"
+            "snippets/controlled-mint"
+            "snippets/data-structures/heap"
+            "snippets/design-patterns/autonomous-objects"
+            "snippets/error-codes"
+            "snippets/fa-lockup-example"
+            "snippets/liquid-nfts"
+            "snippets/lootbox"
+            "snippets/modifying-nfts"
+            "snippets/objects"
+            "snippets/parallel-nfts"
+            "snippets/private-vs-public/dice_roll"
+            "snippets/private-vs-public/cheater"
+            "snippets/prover"
+            "snippets/storage"
+            "snippets/struct-capabilities"
+          )
+
+          failed=0
+          for pkg in "${packages[@]}"; do
+            echo "::group::Compile $pkg"
+            if (cd "$pkg" && aptos move compile --dev); then
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error::Failed to compile $pkg"
+              failed=1
+            fi
+          done
+
+          # fractional-token uses --named-addresses instead of --dev
+          # due to broken TokenMinter dev-dependency
+          echo "::group::Compile snippets/fractional-token"
+          if (cd snippets/fractional-token && aptos move compile --named-addresses fraction_addr=0x1337,minter=0x2337); then
+            echo "::endgroup::"
+          else
+            echo "::endgroup::"
+            echo "::error::Failed to compile snippets/fractional-token"
+            failed=1
+          fi
+
+          exit $failed
 
   test:
     name: Test Examples
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: data-structures-heap
-            path: snippets/data-structures/heap
-          - name: error-codes
-            path: snippets/error-codes
-          - name: fa-lockup-example
-            path: snippets/fa-lockup-example
-          - name: controlled-mint
-            path: snippets/controlled-mint
 
     steps:
       - name: Checkout repository
@@ -89,6 +79,25 @@ jobs:
           curl -fsSL "https://aptos.dev/scripts/install_cli.py" | python3
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Test ${{ matrix.name }}
-        working-directory: ${{ matrix.path }}
-        run: aptos move test --dev
+      - name: Run tests
+        run: |
+          packages=(
+            "snippets/data-structures/heap"
+            "snippets/error-codes"
+            "snippets/fa-lockup-example"
+            "snippets/controlled-mint"
+          )
+
+          failed=0
+          for pkg in "${packages[@]}"; do
+            echo "::group::Test $pkg"
+            if (cd "$pkg" && aptos move test --dev); then
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error::Tests failed in $pkg"
+              failed=1
+            fi
+          done
+
+          exit $failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  APTOS_CLI_VERSION: "7.14.2"
-
 jobs:
   compile:
     name: Compile Examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  APTOS_CLI_VERSION: "7.14.2"
+
+jobs:
+  compile:
+    name: Compile Examples
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: composable-nfts
+            path: snippets/composable-nfts
+          - name: controlled-mint
+            path: snippets/controlled-mint
+          - name: data-structures-heap
+            path: snippets/data-structures/heap
+          - name: autonomous-objects
+            path: snippets/design-patterns/autonomous-objects
+          - name: error-codes
+            path: snippets/error-codes
+          - name: fa-lockup-example
+            path: snippets/fa-lockup-example
+          - name: fractional-token
+            path: snippets/fractional-token
+            # Uses --named-addresses instead of --dev due to broken TokenMinter dev-dependency
+            compile_flags: "--named-addresses fraction_addr=0x1337,minter=0x2337"
+          - name: liquid-nfts
+            path: snippets/liquid-nfts
+          - name: lootbox
+            path: snippets/lootbox
+          - name: modifying-nfts
+            path: snippets/modifying-nfts
+          - name: objects
+            path: snippets/objects
+          - name: parallel-nfts
+            path: snippets/parallel-nfts
+          - name: private-vs-public-dice-roll
+            path: snippets/private-vs-public/dice_roll
+          - name: private-vs-public-cheater
+            path: snippets/private-vs-public/cheater
+          - name: prover
+            path: snippets/prover
+          - name: storage
+            path: snippets/storage
+          - name: struct-capabilities
+            path: snippets/struct-capabilities
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Aptos CLI
+        run: |
+          curl -fsSL "https://aptos.dev/scripts/install_cli.py" | python3
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Compile ${{ matrix.name }}
+        working-directory: ${{ matrix.path }}
+        run: aptos move compile ${{ matrix.compile_flags || '--dev' }}
+
+  test:
+    name: Test Examples
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: data-structures-heap
+            path: snippets/data-structures/heap
+          - name: error-codes
+            path: snippets/error-codes
+          - name: fa-lockup-example
+            path: snippets/fa-lockup-example
+          - name: controlled-mint
+            path: snippets/controlled-mint
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Aptos CLI
+        run: |
+          curl -fsSL "https://aptos.dev/scripts/install_cli.py" | python3
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Test ${{ matrix.name }}
+        working-directory: ${{ matrix.path }}
+        run: aptos move test --dev

--- a/snippets/error-codes/sources/error_codes.move
+++ b/snippets/error-codes/sources/error_codes.move
@@ -70,4 +70,40 @@ module deploy_addr::error_codes {
     entry fun throw_if_false(input: bool) {
         assert!(input == true, E_VALUE_NOT_TRUE)
     }
+
+    // ---- Tests ----
+
+    #[test]
+    /// Verifies that throw_if_false succeeds when given true
+    fun test_throw_if_false_with_true() {
+        throw_if_false(true);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_VALUE_NOT_TRUE)]
+    /// Verifies that throw_if_false aborts with E_VALUE_NOT_TRUE when given false
+    fun test_throw_if_false_with_false() {
+        throw_if_false(false);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_ERROR_WITHOUT_MESSAGE)]
+    /// Verifies that throw_error_code_only aborts with E_ERROR_WITHOUT_MESSAGE
+    fun test_throw_error_code_only() {
+        throw_error_code_only();
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_USEFUL_ERROR)]
+    /// Verifies that throw_useful_error aborts with E_USEFUL_ERROR
+    fun test_throw_useful_error() {
+        throw_useful_error();
+    }
+
+    #[test]
+    #[expected_failure]
+    /// Verifies that throw_classified_error aborts with a classified error code
+    fun test_throw_classified_error() {
+        throw_classified_error();
+    }
 }


### PR DESCRIPTION
Add CI to compile all examples and run tests, and introduce new inline tests for `error-codes` and `controlled-mint`.

The `fractional-token` example is compiled using `--named-addresses` instead of `--dev` due to a pre-existing issue with its `TokenMinter` dev-dependency.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c8f04214-3ed1-4c5c-b5f1-9ad815be505c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8f04214-3ed1-4c5c-b5f1-9ad815be505c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

