### PR TITLE
Pin GitHub Actions to SHA hashes and update checkout to v7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Aptos CLI
         run: |
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Aptos CLI
         run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pins all GitHub Actions references to immutable commit SHAs and updates `actions/checkout` to the latest release that is more than 3 days old.

## Changes

- `.github/workflows/ci.yml`: Replaced `actions/checkout@v4` with `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0` in both the `compile` and `test` jobs.

## Rationale

- **SHA pinning** prevents supply-chain attacks where a mutable tag could be updated to point at malicious code.
- **v7.0.0** (released 2026-06-18) is the latest `actions/checkout` release older than 3 days as of 2026-07-02. Newer commits on `main` (e.g. 2026-06-30) were excluded per the age requirement.

## Verification

- Workflow YAML parses successfully.
- This is the only workflow file in the repository; no other action references were found.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f22b2-51b9-7727-9b79-fbc624280fb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f22b2-51b9-7727-9b79-fbc624280fb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

